### PR TITLE
added support for AWS_S3_CUSTOM_DOMAIN

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,11 @@ Then setup some values used by the backend:
     AWS_SECRET_ACCESS_KEY = 'YourS3SecretAccessKeyHere'
     AWS_STORAGE_BUCKET_NAME = 'OneOfYourBuckets'
 
+If you would like to use a vanity domain instead of s3.amazonaws.com, you
+first should configure it in amazon and then add this to settings:
+
+    AWS_S3_CUSTOM_DOMAIN = 'static.yourdomain.com'
+
 ## Using in models
 
 After you have all of the above configured, you're ready to start using

--- a/athumb/backends/s3boto.py
+++ b/athumb/backends/s3boto.py
@@ -200,7 +200,10 @@ class S3BotoStorage_AllPublic(S3BotoStorage):
         just simply dump out a URL rather than having to query S3 for new keys.
         """
         name = self._clean_name(name)
-        return "http://s3.amazonaws.com/%s/%s" % (self.bucket_name, name)
+        if hasattr(settings, 'AWS_S3_CUSTOM_DOMAIN'):
+            return "http://%s/%s" % (settings.AWS_S3_CUSTOM_DOMAIN, name)
+        else:
+            return "http://s3.amazonaws.com/%s/%s" % (self.bucket_name, name)
 
 class S3BotoStorageFile(File):
     def __init__(self, name, mode, storage):


### PR DESCRIPTION
Previously, users were forced to serve static content from s3.amazonaws.com.
This allows for vanity domain names to be used.
