### PR TITLE
athumb_regen_field doesn't create thumbnails

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ NOTE: This module is primarily aimed at storing and serving images to/from
 S3. I have not tested it at all with the standard Django Filesystem backend,
 though it *should* work.
 
+
 ## Template Tags
 
 When referring to media in HTML templates you can use custom template tags. 
@@ -177,9 +178,21 @@ it, finish the tag with `as [context_var_name]`:
     {% thumbnail image '60x60' as 'thumb' %}
     <img src="{{thumb}}" />
 
+
+## manage.py commands
+
+### athumb_regen_field
+
+    # ./manage.py athumb_regen_field <app.model> <field>
+
+Re-generates thumbnails for all instances of the given model, for the given
+field.
+
+
 ## To-Do
 
 * See the issue tracker for a list of outstanding things needing doing.
+
 
 ## Change Log
 


### PR DESCRIPTION
I'd like to create my thumbnails, and if the designer for my project decides later to change the THUMBS (settings that could be added to django-athumb directly btw), I'd like the outdated thumbnails to be cleaned (removed) and new thumbnails to be created depending on the THUMBS tuples.

Should I go and create a new athumb_gen_field, or should we improve and rename this current manage command ?

Current and only commit for this issue adds missing manage command to doc.
