### PR TITLE
fix a bug: upload_to of the ImageWithThumbnailField will be exercuted in every run of the command

### DIFF
--- a/athumb/management/commands/athumb_regen_field.py
+++ b/athumb/management/commands/athumb_regen_field.py
@@ -107,7 +107,7 @@ class Command(BaseCommand):
             # ThumbnailField. If not, it's still pretty harmless.
 
             try:
-                file.save(file_name, file_contents)
+                file.generate_thumbs(file_name, file_contents)
             except IOError, e:
                 print "(%d/%d) ID %d --  Error -- Image may be corrupt)" % (
                     counter,


### PR DESCRIPTION
if a ImageWithThumbnailField has a upload_to parameter such as this:

```
def upload_to(instance, filename):
    return filename+str(uuid.uuid4())
```

then each time the management commmand runs, the name of the image will be append another uuid.

So we should use _generate_thumbs_ rather than _save_ here.
