### PR TITLE
Configuring Calling Format for S3 URLs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -113,6 +113,22 @@ setting::
 
     AWS_REGION = 'us-east-1'
 
+S3 supports multiple calling formats for bucket URLs. For example, the bucket
+name may be called as a subdomain, or it may be called as a subdirectory. The
+issue with a subdomain call, which is the default in ``boto.s3``, is that SSL
+certificates of wildcarded subdomains are being deprecated for security, so
+HTTPS URLs with bucket subdomains may trigger browser warnings, or, in
+in some cases with Internet Explorer 10, hide the issue behind a connection
+error. Therefore, the default is to use the bucket name as a subdirectory,
+which is done by ``boto.s3.connection.OrdinaryCallingFormat``. To change this,
+set ``URL_CALLING_FORMAT`` to a string describing either a calling format in
+the ``boto.s3.connection`` module, or to a string of a full absolute import
+path (similar to Django middleware). For example, either of the following
+would suffice to use the default subdomain calling format, instead::
+
+    URL_CALLING_FORMAT = 'SubdomainCallingFormat'
+    URL_CALLING_FORMAT = 'boto.s3.connection.SubdomainCallingFormat'
+
 Using in models
 ---------------
 


### PR DESCRIPTION
Debugging alleged connection issues with a secure site that uses S3 storage has revealed that in some instances, the default `SubdomainCallingFormat` used by `boto.s3.connection.S3Connection` for S3 bucket URLs can trip SSL certificate authentication in browsers, since wildcarded subdomains are being deprecated (http://tools.ietf.org/html/rfc6125#section-7.2). In some cases over HTTPS, this could trigger a browser warning, and Internet Explorer 10 on Windows 8 can even hide the issue behind an opaque "Connection Error."

For this reason, I believe the default (indeed, for `boto` as well) should be `boto.s3.connection.OrdinaryCallingFormat`.  I have therefore taken an opinionated approach here of using `OrdinaryCallingFormat` by default when calling `S3Connection` and allowing the user to configure the calling format otherwise using setting import string in `settings.URL_CALLING_FORMAT`.  For more details, please review the documentation update and the addition to `S3BotoStorage.__init__()`.
