### PR TITLE
fix documenation for custom s3 domain setting

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -98,7 +98,7 @@ Then setup some values used by the backend::
 If you would like to use a vanity domain instead of s3.amazonaws.com, you
 first should configure it in amazon and then add this to settings::
 
-    AWS_STORAGE_BUCKET_CNAME = 'static.yourdomain.com'
+    AWS_S3_CUSTOM_DOMAIN = 'static.yourdomain.com'
 
 If you want a cache buster for your thumbnails (a string added to the end of
 the image URL that causes browsers to re-fetch the image after changes), you


### PR DESCRIPTION
The settings `AWS_STORAGE_BUCKET_CNAME` doesn't appear to be used now that the `storages.backends.s3boto` storage backend is back in action. Under they hood, they require `AWS_S3_CUSTOM_DOMAIN` to use a custom `CNAME`.

